### PR TITLE
deps: batch bump for mypy to 1.13.0 and tox to 4.23.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = []
 dev = [
     "build==1.2.0",
     "pre-commit==4.0.1",
-    "tox==4.23.0",
+    "tox==4.23.2",
     "tox-gh-actions==3.2.0"]
 test = [
     "pytest==8.3.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ format = [
     "autopep8==2.3.1",
     "isort==5.13.2"]
 mypy = [
-    "mypy==1.12.0"]
+    "mypy==1.13.0"]
 bandit = [
     "bandit==1.7.10"]
 


### PR DESCRIPTION
This PR merges multiple Dependabot updates into a single batch:

Merged Updates:
- deps: bump mypy from 1.12.0 to 1.13.0 (#4)
- deps: bump tox from 4.23.0 to 4.23.2 (#5)
